### PR TITLE
Clear notification div in new sentences

### DIFF
--- a/db/script/alph-treebank-edit.js
+++ b/db/script/alph-treebank-edit.js
@@ -377,6 +377,9 @@ function InitNewSentence()
     // clear undo/redo history
     AlphEdit.clearHistory();
 
+    // clear past notifications
+    AlphEdit.clearNotifications();
+
     // get and transform treebank sentence
     var sentence;
     var localSentence = $('#sentence-xml').html();


### PR DESCRIPTION
Every time we initialize a new sentence, we want the div to be cleared.

Makes use of alpheios-project/edit-utils#1
Fixes PerseusDL/perseids_docs#20
