### PR TITLE
Retain unknown attributes on Sentence Save

### DIFF
--- a/db/xq/treebank-putsentence.xq
+++ b/db/xq/treebank-putsentence.xq
@@ -77,21 +77,24 @@ return
     if ($oldSentence)
     then
     (
-      (: build content in namespace of existing sentence :)
-      let $ns := namespace-uri($oldSentence)
-      let $newSentence :=
-        element { QName($ns, "sentence") }
-        {
-          $oldSentence/@*,
 
-          for $elt in $sentence/*
-          return
-            element { QName($ns, local-name($elt)) }
-            {
-              $elt/@*,
-              $elt/*
-            }
-        }
+      (:
+        Copy the old sentence and iterate over each element of the updated
+        annotation and its attributes.
+        These attributes replace their old counterparts in place - we just
+        update the contents of the sentence we received. Documents that
+        contain attributes the editor does not know of are therefore retained.
+      :)
+
+      let $newSentence := $oldSentence
+      for $elt in $sentence/*
+        let $id := $elt/@id
+        let $name := local-name($elt)
+        for $attr in $elt/@*
+          let $old_attr :=
+            $oldSentence/*[name()=$name and @id=$id]/@*[name()=name($attr)]
+          let $update := update replace $old_attr with $attr
+
       return update replace $oldSentence with $newSentence,
       element message { "Sentence saved" }
     )


### PR DESCRIPTION
Following PerseusDL/perseids_docs#31 we want to be able to support
additional markup/attributes in treebank files, even if the editor
doesn't support curation of these.

Before this commit a new sentence was built from scratch by using
nodes right out of the editor session when a sentence was saved, now 
we update the attributes we know of in place of the old document.

WARNING: This is not mergeable yet, waiting for approval that this is in 
fact a good way to solve this - I am very open for suggestions on how to 
do it better! 
After such a confirmation I'd have to update the `treebank-putsentence-local.xq`
as well.

Fixes PerseusDL/perseids_docs#31
